### PR TITLE
Port randomization

### DIFF
--- a/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPlugin.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPlugin.groovy
@@ -10,11 +10,13 @@ import de.flapdoodle.embed.process.config.io.ProcessOutput
 import de.flapdoodle.embed.process.runtime.Network
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.slf4j.Logger
 
 import static com.sourcemuse.gradle.plugin.ManageProcessInstruction.CONTINUE_MONGO_PROCESS_WHEN_BUILD_PROCESS_STOPS
 import static com.sourcemuse.gradle.plugin.ManageProcessInstruction.STOP_MONGO_PROCESS_WHEN_BUILD_PROCESS_STOPS
 
 class GradleMongoPlugin implements Plugin<Project> {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(GradleMongoPlugin.class)
 
     static final String PLUGIN_EXTENSION_NAME = 'mongo'
     static final String TASK_GROUP_NAME = 'Mongo'
@@ -64,6 +66,11 @@ class GradleMongoPlugin implements Plugin<Project> {
         ProcessOutput processOutput = new LoggerFactory(project).getLogger(pluginExtension)
         IFeatureAwareVersion version = new VersionFactory().getVersion(pluginExtension)
         Storage storage = new StorageFactory().getStorage(pluginExtension)
+
+        if (pluginExtension.randomPort) {
+            pluginExtension.port = PortUtils.allocateRandomPort()
+            log.info('Selected random MongoDB port: {}', pluginExtension.port)
+        }
 
         IMongodConfig mongodConfig = new MongodConfigBuilder()
                 .version(version)

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
@@ -7,6 +7,7 @@ class GradleMongoPluginExtension {
     static final EPHEMERAL_TEMPORARY_FOLDER = null
 
     int port = 27017
+    boolean randomPort = false
     String bindIp = '127.0.0.1'
     String logging = FILE as String
     String logFilePath = 'embedded-mongo.log'

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/PortUtils.java
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/PortUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2012 Joe Littlejohn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Minor modifications The MITRE Corporation, 2014.
+ */
+package com.sourcemuse.gradle.plugin;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * This is stolen from the Maven embed mongo plugin.
+ *
+ * @author Joe Littlejohn
+ */
+public final class PortUtils {
+    private PortUtils() {
+    }
+
+    /**
+     * Grab a random free port. Note that this is vulnerable to a race condition attack.
+     *
+     * @return the number of an availabl port.
+     * @throws IOException if there is an error grabbing a random port.
+     */
+    public static int allocateRandomPort() throws IOException {
+        try {
+            ServerSocket server = new ServerSocket(0);
+            int port = server.getLocalPort();
+            server.close();
+            return port;
+        } catch (IOException e) {
+            throw new IOException("Failed to acquire a random free port", e);
+        }
+    }
+}

--- a/src/test/groovy/com/sourcemuse/gradle/plugin/BuildScriptBuilder.groovy
+++ b/src/test/groovy/com/sourcemuse/gradle/plugin/BuildScriptBuilder.groovy
@@ -10,6 +10,7 @@ class BuildScriptBuilder {
     String logFilePath
     String mongoVersion
     String storageLocation
+    boolean randomPort
 
     static BuildScriptBuilder buildScript() {
         new BuildScriptBuilder()
@@ -19,7 +20,7 @@ class BuildScriptBuilder {
         def mongoConfigBlock = new MongoPluginConfigBlock()
 
         this.properties.each { name, value ->
-            if (value && value in [port, logging, logFilePath, mongoVersion, storageLocation])
+            if (value && value in [port, logging, logFilePath, mongoVersion, storageLocation, randomPort])
                 mongoConfigBlock.addPropertyConfig(name, "$value")
         }
 
@@ -53,6 +54,11 @@ class BuildScriptBuilder {
 
     BuildScriptBuilder withStorageLocation(String storage) {
         this.storageLocation = storage
+        this
+    }
+
+    BuildScriptBuilder withRandomPort(boolean random) {
+        this.randomPort = random
         this
     }
 

--- a/src/test/groovy/com/sourcemuse/gradle/plugin/TestPlugin.groovy
+++ b/src/test/groovy/com/sourcemuse/gradle/plugin/TestPlugin.groovy
@@ -16,13 +16,21 @@ class TestPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.task(dependsOn: 'startManagedMongoDb', TEST_START_MANAGED_MONGO_DB) << {
-            if (mongoInstanceRunning(DEFAULT_MONGOD_PORT))
-                println MONGO_RUNNING_FLAG
+            def port = project.mongo.port ?: DEFAULT_MONGOD_PORT
+            if (mongoInstanceRunning(port))
+                println MONGO_RUNNING_FLAG + port
         }
         project.task(dependsOn: 'startMongoDb', TEST_START_MONGO_DB) << {
-            if (mongoInstanceRunning(DEFAULT_MONGOD_PORT))
-                println MONGO_RUNNING_FLAG
+            def port = project.mongo.port ?: DEFAULT_MONGOD_PORT
+            if (mongoInstanceRunning(port))
+                println MONGO_RUNNING_FLAG + port
         }
         project.task(dependsOn: ['startMongoDb', 'stopMongoDb'], TEST_STOP_MONGO_DB)
+    }
+
+    static Integer findPortInOutput(String buildStandardOut) {
+        def portMatcher = buildStandardOut =~ "(?i)${MONGO_RUNNING_FLAG}([0-9]+)"
+        def foundPort = portMatcher.find()
+        return foundPort ? Integer.valueOf(portMatcher.group(1)) : null
     }
 }


### PR DESCRIPTION
I added port randomization as an option, similar to the Maven Mongo plugin. You enable it like so:

    mongo {
      randomPort = true
    }

randomPort overrides a port setting. After one of the start mongo tasks executes the port property of the MongoPluginExtension will be set to the randomly selected port. I'm not sure if this is the best way to communicate the selected port to the rest of the build, but TaskOutputs seems to be focused on files and directories, not values.