### PR TITLE
Update to embedded mongo with support for 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.47.0'
+    compile 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.47.1'
 
     testCompile files('libs/gradle-test-kit.jar')
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0', {
         exclude module: 'groovy-all'
     }
-    testCompile 'org.mongodb:mongo-java-driver:2.12.2'
+    testCompile 'org.mongodb:mongo-java-driver:2.13.0'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
This updates the embedded mongo package to the most recent release which supports Mongo 3.0 and 3.1.  It also updates the mongo db java driver to 2.13 which is the minimum needed to support Mongo 3.