### PR TITLE
Support storage engine configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following properties are configurable:
 * ```port```: The port Mongo will listen on (defaults to **27017**). For random port assignment, set this value to **'RANDOM'** (the actual port value used will be available during the build through the **project.mongo.port** property)
 * ```proxyHost```: The proxy host name for Mongo downloads
 * ```proxyPort```: The proxy port for Mongo downloads
+* ```storageEngine```: The name of the storage engine to use. Can be **'wiredTiger'** or **'mmapv1'** for MongoDB Community Edition (default is **'wiredTiger'** for Mongo 3.2 and later; otherwise it is **'mmapv1'**). Alternative distributions might support additional engines.
 * ```storageLocation```: The directory location from where embedded Mongo will run, such as ```/tmp/storage``` (defaults to a java temp directory)
 
 ### Tasks ###

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
@@ -16,6 +16,7 @@ class GradleMongoPluginExtension {
     String logging = FILE as String
     String logFilePath = 'embedded-mongo.log'
     String mongoVersion = 'PRODUCTION'
+    String storageEngine = null
     String storageLocation = EPHEMERAL_TEMPORARY_FOLDER
     String mongodVerbosity = ''
     String downloadUrl = ''

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
@@ -154,6 +154,7 @@ class GradleMongoPlugin implements Plugin<Project> {
     private static IMongoCmdOptions createMongoCommandOptions(GradleMongoPluginExtension pluginExtension) {
         new MongoCmdOptionsBuilder()
                 .useNoJournal(!pluginExtension.journalingEnabled)
+                .useStorageEngine(pluginExtension.storageEngine)
                 .build()
     }
 

--- a/src/test/groovy/com/sourcemuse/gradle/plugin/BuildScriptBuilder.groovy
+++ b/src/test/groovy/com/sourcemuse/gradle/plugin/BuildScriptBuilder.groovy
@@ -48,6 +48,11 @@ class BuildScriptBuilder {
         this
     }
 
+    BuildScriptBuilder withStorageEngine(String storageEngine) {
+        configProperties.storageEngine = asStringProperty(storageEngine)
+        this
+    }
+
     BuildScriptBuilder withStorageLocation(String storage) {
         configProperties.storageLocation = asStringProperty(storage)
         this

--- a/src/test/groovy/com/sourcemuse/gradle/plugin/MongoPluginConfigSpec.groovy
+++ b/src/test/groovy/com/sourcemuse/gradle/plugin/MongoPluginConfigSpec.groovy
@@ -131,6 +131,58 @@ class MongoPluginConfigSpec extends Specification {
         mongoVersion == version
     }
 
+    def 'storage engine can be set to WiredTiger'() {
+        given:
+        generate(buildScript.withMongoVersion(Version.Main.V3_2.asInDownloadPath()).withStorageEngine('wiredTiger'))
+        gradleRunner.arguments << TEST_START_MONGO_DB
+
+        when:
+        gradleRunner.run()
+
+        then:
+        mongoServerStatus().storageEngine.name == 'wiredTiger'
+        noExceptionThrown()
+    }
+
+    def 'storage engine can be set to MMAPv1'() {
+        given:
+        generate(buildScript.withMongoVersion(Version.Main.V3_2.asInDownloadPath()).withStorageEngine('mmapv1'))
+        gradleRunner.arguments << TEST_START_MONGO_DB
+
+        when:
+        gradleRunner.run()
+
+        then:
+        mongoServerStatus().storageEngine.name == 'mmapv1'
+        noExceptionThrown()
+    }
+
+    def 'the default storage engine is WiredTiger for versions after 3.2'() {
+        given:
+        generate(buildScript.withMongoVersion(Version.Main.V3_2.asInDownloadPath()))
+        gradleRunner.arguments << TEST_START_MONGO_DB
+
+        when:
+        gradleRunner.run()
+
+        then:
+        mongoServerStatus().storageEngine.name == 'wiredTiger'
+        noExceptionThrown()
+    }
+
+    def 'the default storage engine is MMAPv1 for versions before 3.0'() {
+        given:
+        generate(buildScript.withMongoVersion(Version.Main.V3_0.asInDownloadPath()))
+        gradleRunner.arguments << TEST_START_MONGO_DB
+
+        when:
+        gradleRunner.run()
+
+        then:
+        mongoServerStatus().storageEngine.name == 'mmapv1'
+        noExceptionThrown()
+    }
+
     def 'replication storage location is configurable'() {
         given:
         def storageDir = tmp.newFolder()

--- a/src/test/groovy/com/sourcemuse/gradle/plugin/MongoUtils.groovy
+++ b/src/test/groovy/com/sourcemuse/gradle/plugin/MongoUtils.groovy
@@ -4,6 +4,8 @@ import static com.sourcemuse.gradle.plugin.BuildScriptBuilder.DEFAULT_MONGOD_POR
 import static com.sourcemuse.gradle.plugin.flapdoodle.gradle.GradleMongoPlugin.PLUGIN_EXTENSION_NAME
 
 import com.mongodb.BasicDBObject
+import com.mongodb.DB
+import com.mongodb.DBObject
 import com.mongodb.MongoClient
 import com.mongodb.WriteConcern
 import de.flapdoodle.embed.mongo.runtime.Mongod
@@ -18,10 +20,18 @@ class MongoUtils {
         Mongod.sendShutdown(InetAddress.getLoopbackAddress(), port)
     }
 
+    static DB mongoDatabase(int port) {
+        def mongoClient = new MongoClient(LOOPBACK_ADDRESS, port)
+        mongoClient.getDB(DATABASE_NAME)
+    }
+
+    static DBObject mongoServerStatus(int port = DEFAULT_MONGOD_PORT) {
+        mongoDatabase(port).eval("db.serverStatus()")
+    }
+
     static boolean mongoInstanceRunning(int port = DEFAULT_MONGOD_PORT) {
         try {
-            def mongoClient = new MongoClient(LOOPBACK_ADDRESS, port)
-            mongoClient.getDB(DATABASE_NAME).getStats()
+            mongoDatabase(port).getStats()
         } catch (Exception e) {
             e.printStackTrace()
             return false


### PR DESCRIPTION
[Embedded MongoDB](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo) supports storage engine selection. However, this is not exposed in GradleMongoPlugin. This PR implements it.