### PR TITLE
Dismiss exceptions from proc.stop()

### DIFF
--- a/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
@@ -189,11 +189,19 @@ class GradleMongoPlugin implements Plugin<Project> {
 
     private static void stopMongoDb(int port, MongodProcess proc) {
         println "Shutting-down Mongod on port ${port}."
+        def force = (proc == null)
 
-        if (proc)
-            proc.stop()
-        else if (!Mongod.sendShutdown(InetAddress.getLoopbackAddress(), port))
+        if (proc) {
+            try {
+                proc.stop()
+            } catch (Exception e) {
+                force = true
+            }
+        }
+
+        if (force && !Mongod.sendShutdown(InetAddress.getLoopbackAddress(), port)) {
             println "Could not shut down mongo, is access control enabled?"
+        }
     }
 
     private static void disableFlapdoodleLogging() {


### PR DESCRIPTION
There are cases where proc.stop() may throw an exception, even when the
mongod process has been successfully killed. Catch that case and attempt
Mongod.sendShutdown instead of failing the build.

See the following for details:
https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/168
https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/212