### PR TITLE
Adding a configuration for mongod syncDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following properties are configurable:
 * ```proxyPort```: The proxy port for Mongo downloads
 * ```storageEngine```: The name of the storage engine to use. Can be **'wiredTiger'** or **'mmapv1'** for MongoDB Community Edition (default is **'wiredTiger'** for Mongo 3.2 and later; otherwise it is **'mmapv1'**). Alternative distributions might support additional engines
 * ```storageLocation```: The directory location from where embedded Mongo will run, such as ```/tmp/storage``` (defaults to a java temp directory)
+* ```syncDelay```: The interval in seconds between fsync operations where mongod flushes its working memory to disk. See [syncdelay parameter](https://docs.mongodb.com/manual/reference/parameters/#param.syncdelay) for more information
 
 ### Tasks ###
 

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/GradleMongoPluginExtension.groovy
@@ -28,6 +28,7 @@ class GradleMongoPluginExtension {
     boolean auth = false
     Map<String, String> args = [:]
     Map<String, String> params = [:]
+    Integer syncDelay = null
 
     void setDownloadUrl(String url) {
         try {

--- a/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
+++ b/src/main/groovy/com/sourcemuse/gradle/plugin/flapdoodle/gradle/GradleMongoPlugin.groovy
@@ -170,11 +170,18 @@ class GradleMongoPlugin implements Plugin<Project> {
     }
 
     private static IMongoCmdOptions createMongoCommandOptions(GradleMongoPluginExtension pluginExtension) {
-        new MongoCmdOptionsBuilder()
+        def mongoCommandOptionsBuilder = new MongoCmdOptionsBuilder()
                 .useNoJournal(!pluginExtension.journalingEnabled)
                 .useStorageEngine(pluginExtension.storageEngine)
                 .enableAuth(pluginExtension.auth)
-                .build()
+
+        if (pluginExtension.syncDelay != null){
+            mongoCommandOptionsBuilder.syncDelay(pluginExtension.syncDelay)
+        } else {
+            mongoCommandOptionsBuilder.defaultSyncDelay()
+        }
+
+        mongoCommandOptionsBuilder.build()
     }
 
     private static void addStopMongoDbTask(Project project) {


### PR DESCRIPTION
This should fix issue #58 

It looks like this happened in the 1.0.4 release when de.flapdoodle.emebed.mongo was updated to 2.0.1

In my opinion, the problem is not actually with this project, and rather with how the default for syncDelay is set in de.flapdoodle.embed.mongo when not explicitly configured in the `MongoCmdOptionsBuilder`.  That project is setting the value to 0 seconds which causes mongo to try to write to disk as fast and hard as it can which typically pegs a CPU core on the running machine (for reference, the [mongo default is 60 seconds](https://docs.mongodb.com/manual/reference/parameters/#param.syncdelay)) .

There was an issue regarding this in that project https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/229, however it was closed with the advice that the client should set the syncDelay themselves.  Therefore I'm submitting this PR here and not over there.

This PR adds syncDelay as a parameter for those who wish to configure it, or if not provided will use the `defaultSyncDelay()` option on the `MongoCmdOptionsBuilder` which will result in starting the mongod process without the `--syncdelay` flag, letting the value fall back on the mongo default