### PR TITLE
Add usage doc for Gradle with Kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ task integrationTest(type: Test) {
 
 ```
 
+If you're using Gradle with Kotlin (build.gradle.kts), use can enable and use the plugin like this:
+
+```kotlin
+plugins {
+    id("com.sourcemuse.mongo") version "2.0.0"
+}
+// ...
+tasks.withType<Test> {
+    extra.set("runWithMongoDb", true)
+}
+```
+
 ### Configuration ###
 
 Configure your Mongo instances inside a ```mongo``` block:


### PR DESCRIPTION
This pull request adds documentation about using the plugin in Kotlin based Gradle (`build.gradle.kts`) file which is slightly different from the normal Groovy based one.